### PR TITLE
Add : ChatList 프로필 이미지 변경

### DIFF
--- a/src/common/postModal/PostModal.jsx
+++ b/src/common/postModal/PostModal.jsx
@@ -19,7 +19,8 @@ const PostModal = ({ modalType, isModalOpen, setIsModalOpen, modalData }) => {
   const navigate = useNavigate();
   const clickOepnProduct = () => {
     setIsModalOpen(!isModalOpen);
-    window.open(modalData.link, '_blank');
+    // window.open(modalData.link, '_blank');
+    window.open('https://github.com/likelion-project-README/README', '_blank');
   };
   const clickDeleteProduct = () => {
     deleteProductsAPI(modalData.id).then((req) => {
@@ -128,7 +129,7 @@ const PostModal = ({ modalType, isModalOpen, setIsModalOpen, modalData }) => {
       <S.ModalWrap>
         <S.ModalOverlay>
           <S.ModalCancleBtn />
-          <S.ModalTxt>채팅방 나가기</S.ModalTxt>
+          <S.ModalTxt onClick={() => navigate(-1)}>채팅방 나가기</S.ModalTxt>
         </S.ModalOverlay>
       </S.ModalWrap>
     );

--- a/src/pages/chatList/ChatList.Style.jsx
+++ b/src/pages/chatList/ChatList.Style.jsx
@@ -18,8 +18,7 @@ export const ChatListTit = styled.h2`
 
 export const ListCont = styled.div`
   padding: 24px 0;
-  /* overflow-y: scroll; */
-  overflow: scroll;
+  overflow-y: scroll;
   ::-webkit-scrollbar {
     display: none; /* Chrome, Safari, Opera*/
   }
@@ -40,11 +39,14 @@ export const ChatWrap = styled.li`
   cursor: pointer;
 `;
 
-export const UserImg = styled.img`
+export const UserImg = styled.img.attrs({
+  alt: '유저 프로필 이미지',
+})`
   width: 42px;
   height: 42px;
   border-radius: 50%;
   background-color: #dbdbdb;
+  object-fit: cover;
 `;
 
 export const UnreadCircle = styled.div`

--- a/src/pages/chatList/ChatList.jsx
+++ b/src/pages/chatList/ChatList.jsx
@@ -24,7 +24,7 @@ const ChatList = () => {
       <S.ListCont>
         <S.List>
           <S.ChatWrap onClick={() => navigate('/chat/:id')}>
-            <S.UserImg />
+            <S.UserImg src='https://images.unsplash.com/photo-1543002588-bfa74002ed7e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80' />
             <S.UnreadCircle />
             <S.UserInfo>
               <S.UserNickName>숨참고딥다이브</S.UserNickName>
@@ -35,10 +35,10 @@ const ChatList = () => {
             </S.UserInfo>
           </S.ChatWrap>
           <S.ChatWrap>
-            <S.UserImg />
+            <S.UserImg src='https://images.unsplash.com/photo-1521714161819-15534968fc5f?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80' />
             <S.UnreadCircle />
             <S.UserInfo>
-              <S.UserNickName>꼬부기</S.UserNickName>
+              <S.UserNickName>피터파커</S.UserNickName>
               <S.ChatInfo>
                 <S.UserChat>책 취향이 너무 좋으셔서 연락드립니다☺️</S.UserChat>
                 <S.ChatDate>2022.12.14</S.ChatDate>
@@ -46,7 +46,7 @@ const ChatList = () => {
             </S.UserInfo>
           </S.ChatWrap>
           <S.ChatWrap>
-            <S.UserImg />
+            <S.UserImg src='https://images.unsplash.com/photo-1592561040789-dbc5d9748568?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80' />
             <S.UserInfo>
               <S.UserNickName>처리짱</S.UserNickName>
               <S.ChatInfo>


### PR DESCRIPTION
## 🍀 무엇을 위한 PR인가요?

- [x] 기능 추가 :
- [x] 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 :

## 🍀 기대 결과

- 채팅 리스트 페이지의 프로필 이미지를 변경했습니다.
- 채팅룸 페이지의 모달에서 채팅방 나가기를 클릭시, 채팅 리스트 페이지로 돌아갑니다.
- 판매중인 상품의 모달에서 웹사이트에서 상품 보기를 클릭시, 리드미 깃허브 레포가 새 창에서 열립니다.

## 🍀 전달사항

-

## 🍀 스크린샷

## 🍀 Issue Number

close : #
