### PR TITLE
Modify : Comment & Tabmenu 컴포넌트 반응형 디자인 수정

### DIFF
--- a/src/common/comment/Comment.Style.jsx
+++ b/src/common/comment/Comment.Style.jsx
@@ -6,11 +6,14 @@ export const CommentCont = styled.div`
   left: 0;
   right: 0;
   border-top: 0.5px solid var(--sub2-text-color);
+  background-color: #fff;
+  z-index: 30;
 `;
 
 export const CommentForm = styled.form`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   padding: 13px 16px 12px 16px;
 `;
 
@@ -32,9 +35,9 @@ export const CommentLab = styled.label`
 `;
 
 export const CommentInp = styled.input`
-  width: 260px;
-  height: 18px;
-  margin-left: 18px;
+  min-width: 260px;
+  max-width: 660px;
+  width: calc(100vw - 118px);
   font-size: 14px;
   color: var(--main-text-color);
   border: none;
@@ -51,7 +54,6 @@ export const CommentInp = styled.input`
 export const PostBtn = styled.button`
   width: 26px;
   height: 18px;
-  margin-left: auto;
   font-size: 14px;
   color: ${(props) => (props.isBtnActive ? 'var(--main-color)' : '#c4c4c4')};
 `;

--- a/src/common/inputBox/InputBox.Style.jsx
+++ b/src/common/inputBox/InputBox.Style.jsx
@@ -7,7 +7,6 @@ export const Box = styled.div`
   flex-direction: column;
   gap: 10px;
   margin: 0 34px 16px 34px;
-  background-color: #fff;
 `;
 
 export const BoxTit = styled.label`

--- a/src/common/tabMenu/TabMenu.Style.jsx
+++ b/src/common/tabMenu/TabMenu.Style.jsx
@@ -7,6 +7,8 @@ export const TabMenuCont = styled.div`
   left: 0;
   right: 0;
   border-top: 0.5px solid var(--sub2-text-color);
+  background-color: #fff;
+  z-index: 30;
 `;
 
 export const TabMenuUl = styled.ul`

--- a/src/pages/profileEdit/ProfileEdit.Style.jsx
+++ b/src/pages/profileEdit/ProfileEdit.Style.jsx
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 import sprite from '../../assets/css_sprites.png';
 
+export const ProfileEditWrap = styled.section`
+  /* height: calc(100vh - 48px); */
+  margin-top: 100px;
+`;
+
 export const ProfileEditTit = styled.h2`
   /* ir */
   position: absolute;

--- a/src/pages/profileEdit/ProfileEdit.jsx
+++ b/src/pages/profileEdit/ProfileEdit.jsx
@@ -155,7 +155,7 @@ const ProfileEdit = () => {
   };
 
   return (
-    <section className='max-width min-width wrapper-contents'>
+    <S.ProfileEditWrap className='max-width min-width wrapper-contents'>
       <S.ProfileEditTit>프로필 수정 페이지</S.ProfileEditTit>
       <form onSubmit={editProfile}>
         <TopBanner type='top-upload-nav' tit='저장' isActive={btnActive} />
@@ -198,7 +198,7 @@ const ProfileEdit = () => {
           onChange={handleUserIntro}
         />
       </form>
-    </section>
+    </S.ProfileEditWrap>
   );
 };
 


### PR DESCRIPTION
## 🍀 무엇을 위한 PR인가요?

- [ ] 기능 추가 :
- [x] 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 :

## 🍀 기대 결과

- 댓글, 탭메뉴 컴포넌트의 배경색을 #fff으로 변경하고, z-index: 30 값을 주었습니다.
- 댓글 컴포넌트의 인풋 창의 너비를 반응형으로 변경했습니다.

## 🍀 전달사항

-

## 🍀 스크린샷

## 🍀 Issue Number

close : #
